### PR TITLE
Allow consumer code to handle promise rejection.

### DIFF
--- a/dagmise.js
+++ b/dagmise.js
@@ -67,7 +67,7 @@ DAG.prototype._make = function (target) {
 				for (var i = 0; i < depnodes.length; i++)
 					deps[depnodes[i]] = depvals[i];
 				return promiser(deps);
-			}, console.error);
+			});
 	}
 	
 	this.node(target, promise);


### PR DESCRIPTION
Currently, all it does is to log the rejection to stderr. By removing this handler, consuming code can attach a handler to the promise returned by make.

```
dag.make('index.html')
.catch(function(error) {
    // handle rejection here
});
```